### PR TITLE
Fix exit code of parallel_rspec

### DIFF
--- a/lib/zeus/parallel_tests/worker.rb
+++ b/lib/zeus/parallel_tests/worker.rb
@@ -1,5 +1,6 @@
 require_relative '../parallel_tests'
 require 'tempfile'
+require 'English'
 
 module Zeus
   module ParallelTests
@@ -22,7 +23,7 @@ module Zeus
       def spawn
         system %(zeus parallel_#{@suite}_worker #{parallel_tests_attributes})
         args_file.unlink
-        $CHILD_STATUS.to_i
+        $CHILD_STATUS.exitstatus
       end
 
       private

--- a/spec/lib/zeus/parallel_tests/worker_spec.rb
+++ b/spec/lib/zeus/parallel_tests/worker_spec.rb
@@ -53,7 +53,7 @@ describe Zeus::ParallelTests::Worker do
 
     it 'returns exit code' do
       system 'true'
-      expect(worker).to receive(:system) { allow($CHILD_STATUS).to receive_messages(to_i: 1) }
+      expect(worker).to receive(:system) { allow($CHILD_STATUS).to receive_messages(exitstatus: 1) }
       expect(subject).to eq(1)
     end
   end


### PR DESCRIPTION
Without `English` being required, `$CHILD_STATUS` in line 26 is
undefined and thus evaluates to `nil`, and `nil.to_i` is `0`. So
parallel_rspec always returned `0` -> success, even when specs
failed.