### PR TITLE
Return the correct exit code

### DIFF
--- a/gemfiles/rails_3_zeus_0.13.gemfile
+++ b/gemfiles/rails_3_zeus_0.13.gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 gem "rails", "3.2.21"
 gem "zeus", "0.13.3"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_3_zeus_0.15.gemfile
+++ b/gemfiles/rails_3_zeus_0.15.gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 gem "rails", "3.2.21"
 gem "zeus", "0.15.4"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4_zeus_0.13.gemfile
+++ b/gemfiles/rails_4_zeus_0.13.gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 gem "rails", "4.2.3"
 gem "zeus", "0.13.3"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4_zeus_0.15.gemfile
+++ b/gemfiles/rails_4_zeus_0.15.gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 gem "rails", "4.2.3"
 gem "zeus", "0.15.4"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/zeus/parallel_tests/worker.rb
+++ b/lib/zeus/parallel_tests/worker.rb
@@ -1,5 +1,6 @@
 require_relative '../parallel_tests'
 require 'tempfile'
+require 'English'
 
 module Zeus
   module ParallelTests
@@ -22,7 +23,7 @@ module Zeus
       def spawn
         system %(zeus parallel_#{@suite}_worker #{parallel_tests_attributes})
         args_file.unlink
-        $CHILD_STATUS.to_i
+        ($CHILD_STATUS && $CHILD_STATUS.exitstatus) || 1
       end
 
       private

--- a/spec/dummy/Guardfile
+++ b/spec/dummy/Guardfile
@@ -3,21 +3,21 @@
 
 guard 'rspec', zeus: true, parallel: true do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { 'spec' }
+  watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb') { 'spec' }
 
   # Rails example
-  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
-  watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
-  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
-  watch(%r{^spec/support/(.+)\.rb$})                  { 'spec' }
-  watch('config/routes.rb')                           { 'spec/routing' }
-  watch('app/controllers/application_controller.rb')  { 'spec/controllers' }
+  watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb|\.haml)$}) { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$}) { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  watch(%r{^spec/support/(.+)\.rb$}) { 'spec' }
+  watch('config/routes.rb') { 'spec/routing' }
+  watch('app/controllers/application_controller.rb') { 'spec/controllers' }
 
   # Capybara features specs
-  watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/features/#{m[1]}_spec.rb" }
+  watch(%r{^app/views/(.+)/.*\.(erb|haml)$}) { |m| "spec/features/#{m[1]}_spec.rb" }
 
   # Turnip features and steps
   watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
 end

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Dummy::Application

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -15,14 +15,14 @@ Dummy::Application.configure do
   config.whiny_nils = true
 
   # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
+  config.action_controller.allow_forgery_protection = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/spec/dummy/script/rails
+++ b/spec/dummy/script/rails
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require File.expand_path('../../config/boot', __FILE__)
 require 'rails/commands'

--- a/spec/lib/zeus/parallel_tests/worker_spec.rb
+++ b/spec/lib/zeus/parallel_tests/worker_spec.rb
@@ -6,7 +6,7 @@ describe Zeus::ParallelTests::Worker do
     let(:cli_env)  { { 'TEST_ENV_NUMBER' => '3' } }
     let(:worker)   { double('worker', spawn: 0) }
     before  { allow(Zeus::ParallelTests::Worker).to receive_messages(new: worker) }
-    subject { Zeus::ParallelTests::Worker.run(cli_argv, cli_env)  }
+    subject { Zeus::ParallelTests::Worker.run(cli_argv, cli_env) }
 
     it 'creates instance of worker' do
       expect(Zeus::ParallelTests::Worker).to receive(:new)
@@ -51,10 +51,16 @@ describe Zeus::ParallelTests::Worker do
       subject
     end
 
-    it 'returns exit code' do
-      system 'true'
-      expect(worker).to receive(:system) { allow($CHILD_STATUS).to receive_messages(to_i: 1) }
+    it 'returns exit code 1 as fallback' do
+      allow_any_instance_of(Process::Status)
+        .to receive_messages(exitstatus: nil)
       expect(subject).to eq(1)
+    end
+
+    it 'returns the original exit code of the command' do
+      allow_any_instance_of(Process::Status)
+        .to receive_messages(exitstatus: 128)
+      expect(subject).to eq(128)
     end
   end
 end

--- a/zeus-parallel_tests.gemspec
+++ b/zeus-parallel_tests.gemspec
@@ -24,13 +24,15 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '<= 0.35.1'
   spec.add_development_dependency 'rspec', '>= 3.0'
 
   # Gems used by dummy app in testing.
-  spec.add_development_dependency 'cucumber-rails'
+  spec.add_development_dependency 'cucumber-core', '<= 3.0.0'
+  spec.add_development_dependency 'cucumber-rails', '<= 1.5.0'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'guard-rspec'
+  spec.add_development_dependency 'rainbow', '<= 2.2.2'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
`$CHILD_STATUS.to_i` does not just return the exit code. As described in the [ruby docs](https://ruby-doc.org/core-2.0.0/Process/Status.html) it returns a 16-bit integer with the process informations and exit code. This will result in a value greater than 255, which is an invalid exit code. Passing a value greater than 255 to `exit` results in an exit code of `0`.
`$CHILD_STATUS.exitstatus` returns just the exit code.

This is similar to #40. I had this problem where on parallel rspec worker crashed but the exit code returned by `zeus-parallel_tests` was still `0`.

I have also fixed the gem versions to work with all tested ruby versions.